### PR TITLE
Fix semver for peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "react-test-renderer": "^16.13.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": ">=16.8.0"
   }
 }


### PR DESCRIPTION
Using this with react 17 and 18 throws npm errors because of the carat range specified for the peerDependency. This tweak should fix it. :)